### PR TITLE
Added revalidate listening to ACL handlers + removed redundant work when doing so

### DIFF
--- a/Packages/com.texelsaur.common/Runtime/Scripts/AccessControl.cs
+++ b/Packages/com.texelsaur.common/Runtime/Scripts/AccessControl.cs
@@ -251,7 +251,7 @@ namespace Texel
         
         public void _RefreshAccessHandlerCheck()
         {
-            DebugLog($"Refresh access handler");
+            DebugLog("Refresh access handler");
             _UpdateHandlers(EVENT_VALIDATE);
         }
 

--- a/Packages/com.texelsaur.common/Runtime/Scripts/AccessControl.cs
+++ b/Packages/com.texelsaur.common/Runtime/Scripts/AccessControl.cs
@@ -121,6 +121,15 @@ namespace Texel
                         source._Register(AccessControlUserSource.EVENT_REVALIDATE, this, nameof(_RefreshWhitelistCheck));
                 }
             }
+
+            if (Utilities.IsValid(accessHandlers))
+            {
+                foreach (AccessControlHandler source in accessHandlers)
+                {
+                    if (Utilities.IsValid(source))
+                        source._Register(AccessControlHandler.EVENT_REVALIDATE, this, nameof(_RefreshWhitelistCheck));
+                }
+            }
         }
 
         public void _AddUserSource(AccessControlUserSource source)

--- a/Packages/com.texelsaur.common/Runtime/Scripts/AccessControl.cs
+++ b/Packages/com.texelsaur.common/Runtime/Scripts/AccessControl.cs
@@ -121,13 +121,13 @@ namespace Texel
                         source._Register(AccessControlUserSource.EVENT_REVALIDATE, this, nameof(_RefreshWhitelistCheck));
                 }
             }
-
+            
             if (Utilities.IsValid(accessHandlers))
             {
                 foreach (AccessControlHandler source in accessHandlers)
                 {
                     if (Utilities.IsValid(source))
-                        source._Register(AccessControlHandler.EVENT_REVALIDATE, this, nameof(_RefreshWhitelistCheck));
+                        source._Register(AccessControlHandler.EVENT_REVALIDATE, this, nameof(_RefreshAccessHandlerCheck));
                 }
             }
         }
@@ -161,7 +161,7 @@ namespace Texel
             }
 
             accessHandlers = (AccessControlHandler[])UtilityTxl.ArrayAddElement(accessHandlers, accessHandler, accessHandler.GetType());
-            accessHandler._Register(AccessControlHandler.EVENT_REVALIDATE, this, nameof(_RefreshWhitelistCheck));
+            accessHandler._Register(AccessControlHandler.EVENT_REVALIDATE, this, nameof(_RefreshAccessHandlerCheck));
 
             _Validate();
         }
@@ -246,6 +246,12 @@ namespace Texel
             }
 
             DebugLog($"Refresh whitelist local={_localPlayerWhitelisted}");
+            _UpdateHandlers(EVENT_VALIDATE);
+        }
+        
+        public void _RefreshAccessHandlerCheck()
+        {
+            DebugLog($"Refresh access handler");
             _UpdateHandlers(EVENT_VALIDATE);
         }
 


### PR DESCRIPTION
Now access handlers actually propagate changes correctly, and no longer force the whitelist to be regenerated as access handlers don't (or at least, shouldn't) interact with whitelist sources - these act as middleware, they don't update the local access variable normally.